### PR TITLE
add policy and role for scara NS [semver:minor]

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -173,5 +173,35 @@ resource "vault_jwt_auth_backend_role" "rollouts_demo" {
 }
 
 
+#
+# Scara Namespace Access
+#
 
+resource "vault_policy" "scara" {
+  name = "scara-deploy"
 
+  policy = <<EOF
+path "secret/*" {
+  capabilities = ["list"]
+}
+path "secret/data/cluster/scara" {
+  capabilities = ["list","read"]
+}
+path "secret/metadata/cluster/scara" {
+  capabilities = ["list","read"]
+}
+EOF
+}
+
+resource "vault_jwt_auth_backend_role" "scara" {
+  backend        = vault_jwt_auth_backend.awesomeci_oidc.path
+  role_name      = "scara-deploy"
+  token_policies = ["nexus-deploy-access", "scara-deploy"]
+
+  bound_claims = {
+    "oidc.circleci.com/project-id" = "b17e553d-f590-48d6-a90d-cbf099bc17f2"
+  }
+  user_claim              = "sub"
+  role_type               = "jwt"
+  user_claim_json_pointer = true
+}


### PR DESCRIPTION
Please allow new scara pipeline https://app.circleci.com/pipelines/github/AwesomeCICD/cera-apps-scara to access vault ns `scara`

- [x] I have added a policy that points to NS specific secrets
- [x] I have created a backend role for auth that includes above policy(ies) 
  - [x] I have the right project ID in the auth role
  - [x] I have the right contexts in auth role OR have dropped context enforcement
- [x] I need nexus (docker push) and included it
  - [ ] I do NOT need nexus
- [x] i ran `terraform fmt`