### PR TITLE
Adding in new Roles and ODIC Provider for GHA BOA Compare [semver:minor] 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -171,7 +171,7 @@ resource "vault_jwt_auth_backend_role" "boa_dev_gha_fork" {
   token_policies = ["nexus-deploy-access", "boa-dev-deploy"]
 
   bound_claims = {
-    "repository": "AwesomeCICD/github-actions-bank-of-aion"
+    "repository" : "AwesomeCICD/github-actions-bank-of-aion"
   }
   user_claim              = "actor"
   role_type               = "jwt"
@@ -184,7 +184,7 @@ resource "vault_jwt_auth_backend_role" "boa_prod_gha_fork" {
   token_policies = ["nexus-deploy-access", "boa-prod-deploy"]
 
   bound_claims = {
-    "repository": "AwesomeCICD/github-actions-bank-of-aion"
+    "repository" : "AwesomeCICD/github-actions-bank-of-aion"
   }
   user_claim              = "actor"
   role_type               = "jwt"


### PR DESCRIPTION
## Add Namespace: N/A

#### Project
https://github.com/AwesomeCICD/github-actions-bank-of-aion

#### Appspaces PR
N/A

- [ ] I have added a policy that points to NS specific secrets
- [X] I have created a backend role for auth that includes above policy(ies) 
  - [X] I have the right project ID in the auth role
  - [X] I have the right contexts in auth role OR have dropped context enforcement
- [X] I need nexus (docker push) and included it
  - [ ] I do NOT need nexus
- [X] i ran `terraform fmt`


### Concerns
We are adding in a new ODIC provider, GHA, and are unsure if the new provider will work. But need to try it out. 

Docs to help with GHA ODIC: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-hashicorp-vault