### PR TITLE
policy: working-title: add access to nexus deployer for app pipline [semver:minor]

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -271,3 +271,20 @@ resource "vault_jwt_auth_backend_role" "dc-db-demo-app" {
   role_type               = "jwt"
   user_claim_json_pointer = true
 }
+
+#
+# Working Title (Server Test Hack App)
+#
+
+resource "vault_jwt_auth_backend_role" "working-title" {
+  backend        = vault_jwt_auth_backend.awesomeci_oidc.path
+  role_name      = "working-title-deploy"
+  token_policies = ["nexus-deploy-access"]
+
+  bound_claims = {
+    "oidc.circleci.com/project-id" = "cb279ff5-ab6b-4c53-9728-ac63c8173bfb"
+  }
+  user_claim              = "sub"
+  role_type               = "jwt"
+  user_claim_json_pointer = true
+}


### PR DESCRIPTION
## Grant access to Working Title Server Test Containers

#### Project
supports https://github.com/CircleCI-Labs/working_title


- [ ] I have added a policy that points to NS specific secrets - NOT NEEDED
- [x] I have created a backend role for auth that includes above policy(ies) 
  - [x] I have the right project ID in the auth role
  - [x] I have the right contexts in auth role OR have dropped context enforcement
- [x] I need nexus (docker push) and included it
  - [ ] I do NOT need nexus
- [ ] i ran `terraform fmt`
