### PR TITLE
[semver:minor] add policies for training NS and user

### DIFF
--- a/roles_policies_training.tf
+++ b/roles_policies_training.tf
@@ -1,0 +1,64 @@
+
+resource "vault_jwt_auth_backend_role" "training_prod" {
+  backend        = vault_jwt_auth_backend.awesomeci_oidc.path
+  role_name      = "training-prod-deploy"
+  token_policies = ["nexus-deploy-access", "training-prod-deploy"]
+
+  bound_claims = {
+    "oidc.circleci.com/context-ids" = "87c698a8-77fd-4ec0-935a-51ee55904aae"
+    "oidc.circleci.com/project-id"  = "fd5dc210-23ad-42e5-b01e-417320fc3945"
+  }
+  user_claim              = "sub"
+  role_type               = "jwt"
+  user_claim_json_pointer = true
+}
+
+resource "vault_jwt_auth_backend_role" "training_dev" {
+  backend        = vault_jwt_auth_backend.awesomeci_oidc.path
+  role_name      = "training-dev-deploy"
+  token_policies = ["nexus-deploy-access", "training-dev-deploy"]
+
+  bound_claims = {
+    "oidc.circleci.com/context-ids" = "7cf67bf2-cf99-4cc7-8ae5-a0daf86ae02b"
+    "oidc.circleci.com/project-id"  = "fd5dc210-23ad-42e5-b01e-417320fc3945"
+  }
+  user_claim              = "sub"
+  role_type               = "jwt"
+  user_claim_json_pointer = true
+}
+
+
+
+
+
+resource "vault_policy" "training_prod" {
+  name = "training-prod-deploy"
+
+  policy = <<EOF
+path "secret/*" {
+  capabilities = ["list"]
+}
+path "secret/data/cluster/training" {
+  capabilities = ["list","read"]
+}
+path "secret/metadata/cluster/training" {
+  capabilities = ["list","read"]
+}
+EOF
+}
+
+resource "vault_policy" "training_dev" {
+  name = "training-dev-deploy"
+
+  policy = <<EOF
+path "secret/*" {
+  capabilities = ["list"]
+}
+path "secret/data/cluster/training-dev" {
+  capabilities = ["list","read"]
+}
+path "secret/metadata/cluster/training-dev" {
+  capabilities = ["list","read"]
+}
+EOF
+}

--- a/roles_policies_training.tf
+++ b/roles_policies_training.tf
@@ -6,7 +6,7 @@ resource "vault_jwt_auth_backend_role" "training_prod" {
 
   bound_claims = {
     "oidc.circleci.com/context-ids" = "87c698a8-77fd-4ec0-935a-51ee55904aae"
-    "oidc.circleci.com/project-id"  = "fd5dc210-23ad-42e5-b01e-417320fc3945"
+    "oidc.circleci.com/project-id"  = "44fc5d2d-186d-44e6-9364-56d19b0a5ecb"
   }
   user_claim              = "sub"
   role_type               = "jwt"
@@ -20,7 +20,7 @@ resource "vault_jwt_auth_backend_role" "training_dev" {
 
   bound_claims = {
     "oidc.circleci.com/context-ids" = "7cf67bf2-cf99-4cc7-8ae5-a0daf86ae02b"
-    "oidc.circleci.com/project-id"  = "fd5dc210-23ad-42e5-b01e-417320fc3945"
+    "oidc.circleci.com/project-id"  = "44fc5d2d-186d-44e6-9364-56d19b0a5ecb5"
   }
   user_claim              = "sub"
   role_type               = "jwt"


### PR DESCRIPTION
---
name: Team PR Template for Updating Policy
title: Policy for namespace FOO [semver:minor]

---
## Add Namespace: `training` and `training-dev`

#### Project
<!-- Make sure you have already created at least a skeleton project. You must use that project ID in auth role claims -->
https://app.circleci.com/pipelines/github/AwesomeCICD/scorm-training-export

#### Appspaces PR
<!-- This change should only be needed when adding new namesapves to the ceratf-module-appspaces repository.  Link corresponding PR here -->
AwesomeCICD/ceratf-module-appspaces#9

- [x] I have added a policy that points to NS specific secrets
- [x] I have created a backend role for auth that includes above policy(ies) 
  - [x] I have the right project ID in the auth role
  - [x] I have the right contexts in auth role OR have dropped context enforcement
- [x] I need nexus (docker push) and included it
  - [ ] I do NOT need nexus
- [x] i ran `terraform fmt`
