### PR TITLE
[semver:patch] fix training project id

### DIFF
--- a/roles_policies_training.tf
+++ b/roles_policies_training.tf
@@ -20,7 +20,7 @@ resource "vault_jwt_auth_backend_role" "training_dev" {
 
   bound_claims = {
     "oidc.circleci.com/context-ids" = "7cf67bf2-cf99-4cc7-8ae5-a0daf86ae02b"
-    "oidc.circleci.com/project-id"  = "44fc5d2d-186d-44e6-9364-56d19b0a5ecb5"
+    "oidc.circleci.com/project-id"  = "44fc5d2d-186d-44e6-9364-56d19b0a5ecb"
   }
   user_claim              = "sub"
   role_type               = "jwt"


### PR DESCRIPTION
---
name: Team PR Template for Updating Policy
title: Policy for namespace FOO [semver:minor]

---
## Add Namespace: <NEW_NS>

#### Project
<!-- Make sure you have already created at least a skeleton project. You must use that project ID in auth role claims -->
https://app.circleci.com/pipelines/github/AwesomeCICD/cera-apps-scara

#### Appspaces PR
<!-- This change should only be needed when adding new namesapves to the ceratf-module-appspaces repository.  Link corresponding PR here -->
AwesomeCICD/ceratf-module-appspaces#1

- [ ] I have added a policy that points to NS specific secrets
- [ ] I have created a backend role for auth that includes above policy(ies) 
  - [ ] I have the right project ID in the auth role
  - [ ] I have the right contexts in auth role OR have dropped context enforcement
- [ ] I need nexus (docker push) and included it
  - [ ] I do NOT need nexus
- [ ] i ran `terraform fmt`
