### PR TITLE
adds new circle-shop role and policies [semver:minor]

### DIFF
--- a/roles_policies_shop.tf
+++ b/roles_policies_shop.tf
@@ -1,0 +1,49 @@
+
+#
+# Dr Demo Namespace Access
+#
+
+resource "vault_policy" "circle-shop" {
+  name = "circle-shop-deploy"
+
+  policy = <<EOF
+path "secret/*" {
+  capabilities = ["list"]
+}
+path "secret/data/cluster/circle-shop" {
+  capabilities = ["list","read"]
+}
+path "secret/metadata/cluster/circle-shop" {
+  capabilities = ["list","read"]
+}
+EOF
+}
+
+resource "vault_policy" "circle-shop-dev" {
+  name = "circle-shop-dev-deploy"
+
+  policy = <<EOF
+path "secret/*" {
+  capabilities = ["list"]
+}
+path "secret/data/cluster/circle-shop-dev" {
+  capabilities = ["list","read"]
+}
+path "secret/metadata/cluster/circle-shop-dev" {
+  capabilities = ["list","read"]
+}
+EOF
+}
+resource "vault_jwt_auth_backend_role" "circle-shop" {
+  backend        = vault_jwt_auth_backend.awesomeci_oidc.path
+  role_name      = "circle-shop-deploy"
+  token_policies = ["nexus-deploy-access", "circle-shop-deploy", "circle-shop-dev-deploy"]
+
+  bound_claims = {
+    "oidc.circleci.com/project-id" = "909be1b0-e447-4eea-8cc1-5f04ebf803ed"
+  }
+  user_claim              = "sub"
+  role_type               = "jwt"
+  user_claim_json_pointer = true
+}
+


### PR DESCRIPTION

## Add Namespace: circle-shop & circle-shop-dev

#### Project
<!-- Make sure you have already created at least a skeleton project. You must use that project ID in auth role claims -->
https://app.circleci.com/pipelines/github/AwesomeCICD/circle-shop

#### Appspaces PR
<!-- This change should only be needed when adding new namesapves to the ceratf-module-appspaces repository.  Link corresponding PR here -->
AwesomeCICD/ceratf-module-appspaces#10

- [x] I have added a policy that points to NS specific secrets
- [x] I have created a backend role for auth that includes above policy(ies) 
  - [x] I have the right project ID in the auth role
  - [x] I have the right contexts in auth role OR have dropped context enforcement
- [x] I need nexus (docker push) and included it
  - [ ] I do NOT need nexus
- [x] i ran `terraform fmt`
